### PR TITLE
Patches to support MINGW build

### DIFF
--- a/TWAIN_DSM/src/CMakeLists.txt
+++ b/TWAIN_DSM/src/CMakeLists.txt
@@ -1,5 +1,8 @@
+#project name
+PROJECT(twaindsm)
+
 # this is just a basic CMakeLists.txt, for more information see the cmake manpage...
-cmake_minimum_required(VERSION 2.4)
+cmake_minimum_required(VERSION 2.8)
 
 # Setup the install prefix, if it's not already defined
 IF(NOT CMAKE_INSTALL_PREFIX)
@@ -15,6 +18,8 @@ ENDIF(NOT CMAKE_BUILD_TYPE)
 IF(APPLE)
 	SET(CMAKE_OSX_ARCHITECTURES "i386;x86_64")
 	ADD_DEFINITIONS(-Wall -Wextra -Werror -isysroot /Developer/SDKs/MacOSX10.6.sdk -mmacosx-version-min=10.6 -fexceptions -fPIC)
+ELSEIF(MINGW)
+    ADD_DEFINITIONS(-Wall -Wextra)
 ELSE()
 	ADD_DEFINITIONS(-Wall -Wextra -Werror)
 ENDIF()
@@ -22,12 +27,9 @@ ENDIF()
 #let's not be sharing our symbols...
 IF(APPLE)
 	SET(CMAKE_SHARED_LINKER_FLAGS "-Wl,-ldl -Wl,-framework,CoreServices -Wl,-framework,Foundation")
-ELSE()
+ELSEIF(NOT MINGW)
 	SET(CMAKE_SHARED_LINKER_FLAGS "-Wl,-Bsymbolic -Wl,--no-undefined -Wl,-ldl")
 ENDIF()
-
-#project name
-PROJECT(twaindsm)
 
 #project version
 SET(${PROJECT_NAME}_MAJOR_VERSION 2)
@@ -35,17 +37,28 @@ SET(${PROJECT_NAME}_MINOR_VERSION 4)
 SET(${PROJECT_NAME}_PATCH_LEVEL 0)
 
 #build a shared library
-ADD_LIBRARY(twaindsm SHARED dsm.cpp apps.cpp log.cpp)
-target_link_libraries(twaindsm dl)
+IF(MINGW)
+	ADD_LIBRARY(twaindsm SHARED dsm.cpp apps.cpp log.cpp hook.cpp dsm.def)
+ELSE()
+	ADD_LIBRARY(twaindsm SHARED dsm.cpp apps.cpp log.cpp)
+	target_link_libraries(twaindsm dl)
+ENDIF()
 
 #
 SET_TARGET_PROPERTIES(twaindsm PROPERTIES
 					  VERSION ${${PROJECT_NAME}_MAJOR_VERSION}.${${PROJECT_NAME}_MINOR_VERSION}.${${PROJECT_NAME}_PATCH_LEVEL}
 					  SOVERSION ${${PROJECT_NAME}_MAJOR_VERSION})
+IF(MINGW)
+	SET_TARGET_PROPERTIES(twaindsm PROPERTIES PREFIX "")
+ENDIF()
 
 #add an install target here
 INSTALL(FILES twain.h DESTINATION include)
-INSTALL(TARGETS twaindsm 
+INSTALL(TARGETS twaindsm
 		LIBRARY DESTINATION lib
-		PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+		PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+		RUNTIME DESTINATION bin COMPONENT libraries
+		ARCHIVE DESTINATION lib COMPONENT libraries
+		LIBRARY DESTINATION lib COMPONENT libraries
+)
 

--- a/TWAIN_DSM/src/apps.cpp
+++ b/TWAIN_DSM/src/apps.cpp
@@ -424,11 +424,11 @@ TW_UINT16 CTwnDsmApps::AddApp(TW_IDENTITY *_pAppId,
   }
 
   // Work out the full path to our drivers (if needed)...
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     (void)::GetWindowsDirectory(szDsm,sizeof(szDsm));
     SSTRCAT(szDsm,sizeof(szDsm),"\\");
     SSTRCAT(szDsm,sizeof(szDsm),kTWAIN_DS_DIR);
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     SSTRCPY(szDsm,sizeof(szDsm),kTWAIN_DS_DIR);
   #else
     #error Sorry, we do not recognize this system...
@@ -1147,7 +1147,7 @@ int CTwnDsmAppsImpl::scanDSDir(char        *_szAbsPath,
   //
   // Take care of VC++...
   //
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     WIN32_FIND_DATA   FileData;             // Data structure describes the file found
     HANDLE            hSearch;              // Search handle returned by FindFirstFile
     char              szABSFilename[FILENAME_MAX];
@@ -1242,7 +1242,7 @@ int CTwnDsmAppsImpl::scanDSDir(char        *_szAbsPath,
   //
   // Take care of g++...
   //
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     #if (TWNDSM_OS == TWNDSM_OS_MACOSX)
 
       char szABSFilename[FILENAME_MAX];
@@ -1385,7 +1385,7 @@ TW_INT16 CTwnDsmApps::LoadDS(TW_IDENTITY  *_pAppId,
       &&  m_ptwndsmappsimpl->m_AppInfo[(TWID_T)_pAppId->Id].pDSList
       &&  (_DsId < MAX_NUM_DS))
   {
-    #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+    #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
       // Make the DS directory the current directoy while we load the DS so that any DLLs that
       // are loaded with the DS can be found.
 	  char		*szResult;
@@ -1418,7 +1418,7 @@ TW_INT16 CTwnDsmApps::LoadDS(TW_IDENTITY  *_pAppId,
                                      m_ptwndsmappsimpl->m_AppInfo[(TWID_T)_pAppId->Id].pDSList->DSInfo[_DsId].szPath,
                                      _DsId,
                                      true);
-    #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+    #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
       if(0!=strlen(szPrevWorkDir))
       {
         (void)_chdir( szPrevWorkDir );
@@ -1489,14 +1489,14 @@ TW_INT16 CTwnDsmAppsImpl::LoadDS(TW_IDENTITY *_pAppId,
   // Try to load the driver...  We load the driver again if we are keeping
   // it open.  This LoadLibrary is always closed so we dont hook this time.
   pDSInfo->pHandle = (TW_HANDLE)LOADLIBRARY(_pPath,false,0);
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     if (0 == pDSInfo->pHandle)
     {
       kLOG((kLOGERR,"Could not load library: %s",_pPath));
       AppSetConditionCode(_pAppId,TWCC_OPERATIONERROR);
       return TWRC_FAILURE;
     }
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     if (0 == pDSInfo->pHandle)
     {
       // This is a bit skanky, and not the sort of thing I really want
@@ -1522,7 +1522,7 @@ TW_INT16 CTwnDsmAppsImpl::LoadDS(TW_IDENTITY *_pAppId,
 
   if (pDSInfo->DS_Entry == 0)
   {
-    #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+    #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
       // The WIATwain.ds does not have an entry point 
       if(0 != strstr(_pPath, "wiatwain.ds"))
       {
@@ -1671,14 +1671,14 @@ TW_INT16 CTwnDsmAppsImpl::LoadDS(TW_IDENTITY *_pAppId,
   if (_boolKeepOpen == true)
   {
     pDSInfo->pHandle = (TW_HANDLE)LOADLIBRARY(_pPath,hook,_DsId);
-    #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+    #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     if (0 == pDSInfo->pHandle)
     {
       kLOG((kLOGERR,"Could not load library: %s",_pPath));
       AppSetConditionCode(_pAppId,TWCC_OPERATIONERROR);
       return TWRC_FAILURE;
     }
-    #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+    #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     if (0 == pDSInfo->pHandle)
     {
       // This is a bit skanky, and not the sort of thing I really want
@@ -1703,7 +1703,7 @@ TW_INT16 CTwnDsmAppsImpl::LoadDS(TW_IDENTITY *_pAppId,
     pDSInfo->DS_Entry = (DSENTRYPROC)DSM_LoadFunction(pDSInfo->pHandle,"DS_Entry");
     if (pDSInfo->DS_Entry == 0)
     {
-      #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+      #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
         // The WIATwain.ds does not have an entry point 
         if(0 != strstr(_pPath, "wiatwain.ds"))
         {
@@ -1758,7 +1758,7 @@ void CTwnDsmApps::UnloadDS(TW_IDENTITY  *_pAppId,
     retval = UNLOADLIBRARY(m_ptwndsmappsimpl->m_AppInfo[(TWID_T)_pAppId->Id].pDSList->DSInfo[_DsId].pHandle,true,_DsId);
 
 	// Log if something bad happens...
-    #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+    #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
       if(0 == retval)
       {
         kLOG((kLOGERR,"failed to unload datasource"));
@@ -1785,7 +1785,7 @@ void CTwnDsmApps::UnloadDS(TW_IDENTITY  *_pAppId,
 */
 void CTwnDsmApps::AppWakeup(TW_IDENTITY *_pAppId)
 {
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
   BOOL boolResult;
     if (   AppValidateId(_pAppId)
         && m_ptwndsmappsimpl->m_AppInfo[(TWID_T)_pAppId->Id].hwnd)
@@ -1798,7 +1798,7 @@ void CTwnDsmApps::AppWakeup(TW_IDENTITY *_pAppId)
         kLOG((kLOGERR,"PostMessage failed..."));
       }
     }
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     kLOG((kLOGERR,"We shouldn't be here in AppWakeup..."));
     // We don't support this path on this platform, use
     // callbacks instead...

--- a/TWAIN_DSM/src/dsm.cpp
+++ b/TWAIN_DSM/src/dsm.cpp
@@ -90,7 +90,7 @@ CTwnDsmLog *g_ptwndsmlog    = 0; /**< The logging object, only access through ma
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wall"
 #endif
-#if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+#if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
 typedef struct
 {
   TW_INT16  Language;     /**< Language */
@@ -223,7 +223,7 @@ static TwLocalize s_twlocalize[] =
       {TWLG_VIETNAMESE,         VIETNAMESE_CHARSET, MAKELANGID(LANG_VIETNAMESE,SUBLANG_NEUTRAL),                "","","",""},
       {-1, 0, 0, 0, 0, 0, 0} // must be last...
 };
-#elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+#elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     // We don't have anything for here...
 #else
     #error Sorry, we do not recognize this system...
@@ -1293,9 +1293,9 @@ TW_INT16 CTwnDsm::OpenDS(TW_IDENTITY *_pAppId,
        && _pAppId->ProtocolMinor == 0 )
      || _pAppId->ProtocolMajor < 2 ) 
     {
-      #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+      #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
         // skip...
-      #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+      #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
 		int iResult;
         FILE *pfile;
         char *szHome;
@@ -1412,7 +1412,7 @@ TW_INT16 CTwnDsm::CloseDS(TW_IDENTITY *_pAppId,
 
 
 
-#if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+#if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
 /**
 * DllMain is only needed for Windows, and it's only needed to collect
 * our instance handle, which is also our module handle.  Don't ever
@@ -1450,7 +1450,7 @@ BOOL WINAPI DllMain(HINSTANCE _hmodule,
   }
   return(TRUE);
 }
-#elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+#elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     // Nothing for us to do...
 #else
     #error Sorry, we do not recognize this system...
@@ -1458,7 +1458,7 @@ BOOL WINAPI DllMain(HINSTANCE _hmodule,
 
 
 
-#if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+#if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
 /**
 * We support a selection dialog on Windows.  I wish we didn't, it's
 * more trouble than it's worth, but it's part of that legacy thing.
@@ -1483,7 +1483,7 @@ BOOL CALLBACK SelectDlgProc(HWND   _hWnd,
     return TRUE;
   }
 }
-#elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+#elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
   // We don't have one of these...
 #else
   #error Sorry, we do not recognize this system...
@@ -1491,7 +1491,7 @@ BOOL CALLBACK SelectDlgProc(HWND   _hWnd,
 
 
 
-#if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+#if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
 /**
 * We support a selection dialog on Windows.  This function is
 * part of our CTwnDsm class, so we don't have to have a lot
@@ -1783,7 +1783,7 @@ BOOL CTwnDsm::SelectDlgProc(HWND hWnd,
   }
   return FALSE;
 }
-#elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+#elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
   // We don't have anything to do on Linux...
 #else
   #error Sorry, we do not recognize this system...
@@ -1832,7 +1832,7 @@ TW_INT16 CTwnDsm::DSM_SelectDS(TW_IDENTITY *_pAppId,
   _pDsId->Id = 0;
 
   // Windows...
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
 
       HKEY      hKey;
       long      status;
@@ -1937,7 +1937,7 @@ TW_INT16 CTwnDsm::DSM_SelectDS(TW_IDENTITY *_pAppId,
       return result;
 
   // We don't support the user selection box on linux...
-  #elif  (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif  (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
 
     pod.m_ptwndsmapps->AppSetConditionCode(_pAppId,TWCC_BADPROTOCOL);
     return TWRC_FAILURE;
@@ -2002,7 +2002,7 @@ TW_INT16 CTwnDsm::DSM_SetDefaultDS(TW_IDENTITY *_pAppId,
   }
 
   // Windows... save default source to Registry  
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     HKEY      hKey;
     long      status = ERROR_SUCCESS;
 
@@ -2031,7 +2031,7 @@ TW_INT16 CTwnDsm::DSM_SetDefaultDS(TW_IDENTITY *_pAppId,
     }
 
   // Linux looks in the user's directory...
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     int iResult;
     FILE *pfile;
     char *szHome;
@@ -2234,7 +2234,7 @@ TW_INT16 CTwnDsm::GetMatchingDefault(TW_IDENTITY *_pAppId,
   memset(pod.m_DefaultDSPath,0,sizeof(pod.m_DefaultDSPath));
 
   // Windows uses the registry...
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     HKEY hKey;
     if (RegOpenKeyEx(HKEY_CURRENT_USER,
                      TWNDSM_DS_REG_LOC,
@@ -2252,7 +2252,7 @@ TW_INT16 CTwnDsm::GetMatchingDefault(TW_IDENTITY *_pAppId,
     }
 
   // Linux looks in the user's directory...
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     int iResult;
     FILE *pfile;
     char *szHome;
@@ -3753,7 +3753,7 @@ TW_HANDLE PASCAL DSM_MemAllocate (TW_UINT32 _bytes)
   }
 
   // Windows...
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     handle = (TW_HANDLE)::GlobalAlloc(GPTR,_bytes);
   if (0 == handle)
   {
@@ -3773,7 +3773,7 @@ TW_HANDLE PASCAL DSM_MemAllocate (TW_UINT32 _bytes)
   return handle;
 
   // Linux
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     handle = (TW_HANDLE)calloc(_bytes,1);
   if (0 == handle)
   {
@@ -3804,7 +3804,7 @@ void PASCAL DSM_MemFree (TW_HANDLE _handle)
   }
 
   // Windows...
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     ::GlobalFree(_handle);
     
   // MacOS
@@ -3812,7 +3812,7 @@ void PASCAL DSM_MemFree (TW_HANDLE _handle)
     DisposeHandle((Handle)_handle);
 
   // Linux...
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     free(_handle);
 
   // Oops...
@@ -3839,7 +3839,7 @@ TW_MEMREF PASCAL DSM_MemLock (TW_HANDLE _handle)
   // lock, since we allocated with GPTR, but I'm nervous
   // that we might get a GHND sent to us.  And since
   // this is a no-op for a GPTR, what they hey...
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     return (TW_MEMREF)::GlobalLock(_handle);
 
   // MacOS
@@ -3847,7 +3847,7 @@ TW_MEMREF PASCAL DSM_MemLock (TW_HANDLE _handle)
     return _handle ? *_handle : 0;
 
   // Linux...
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     return (TW_MEMREF)_handle;
 
   // Oops...
@@ -3873,11 +3873,11 @@ void PASCAL DSM_MemUnlock (TW_HANDLE _handle)
   }
 
   // Windows...
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     ::GlobalUnlock(_handle);
 
   // Linux...
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
 
   // Oops...
   #else
@@ -3897,14 +3897,14 @@ void* DSM_LoadFunction(void* _pHandle, const char* _pszSymbol)
 					   CFStringCreateWithCStringNoCopy(0, _pszSymbol, kCFStringEncodingUTF8, 0));
 #else
 
-  #if (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #if (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     dlerror();    /* Clear any existing error */
   #endif
 
   // Try to get the entry point...
   pRet = LOADFUNCTION(_pHandle, _pszSymbol);
 
-#if (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+#if (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
   char* psz_error = 0;
 
   if((psz_error = dlerror()) != NULL)

--- a/TWAIN_DSM/src/dsm.cpp
+++ b/TWAIN_DSM/src/dsm.cpp
@@ -3902,7 +3902,7 @@ void* DSM_LoadFunction(void* _pHandle, const char* _pszSymbol)
   #endif
 
   // Try to get the entry point...
-  pRet = LOADFUNCTION(_pHandle, _pszSymbol);
+  pRet = (void*)LOADFUNCTION(_pHandle, _pszSymbol);
 
 #if (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
   char* psz_error = 0;

--- a/TWAIN_DSM/src/dsm.h
+++ b/TWAIN_DSM/src/dsm.h
@@ -97,7 +97,9 @@
   #if defined(__GNUC__)
     #define TWNDSM_CMP              TWNDSM_CMP_GNUGPP
     #define TWNDSM_CMP_VERSION      __GNUC__
-    #if defined(__APPLE__)
+    #if defined(_WIN32)
+      #define TWNDSM_OS             TWNDSM_OS_WINDOWS
+    #elif defined(__APPLE__)
       #define TWNDSM_OS             TWNDSM_OS_MACOSX
     #else
       #define TWNDSM_OS             TWNDSM_OS_LINUX
@@ -130,7 +132,7 @@
 /**
 *  Pull in the system specific headers...
 */
-#if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+#if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
   #ifndef WIN32_LEAN_AND_MEAN
     #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
   #endif
@@ -138,7 +140,7 @@
   #include <direct.h>
   #include <share.h>
 
-#elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+#elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
   #include <dirent.h>
   #include <dlfcn.h>
   #include <unistd.h>
@@ -251,7 +253,7 @@
 * @def kTWAIN_DS_DIR
 * The path to where TWAIN Data Sources are stored on the system
 */
-#if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+#if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
 
   // Define TW_IDENTITY.Id
   #define TWID_T TW_UINT32
@@ -306,7 +308,7 @@
     #endif
   #endif
 
-#elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+#elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
   #define DllExport
   #define NCHARS(s) sizeof(s)/sizeof(s[0])
   #define PATH_SEPERATOR '/'
@@ -397,7 +399,7 @@
 * @param[in] n the source string
 * 
 */
-#if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP) && (TWNDSM_CMP_VERSION >= 1400)
+#if (TWNDSM_OS == TWNDSM_OS_WINDOWS) && (TWNDSM_CMP_VERSION >= 1400)
   #define SSTRCPY(d,z,s) strncpy_s(d,z,s,_TRUNCATE)
   #define SSTRCAT(d,z,s) strncat_s(d,z,s,_TRUNCATE)
   #define SSTRNCPY(d,z,s,m) strncpy_s(d,z,s,m)
@@ -427,9 +429,9 @@
       int result;
       va_list valist;
       va_start(valist,f);
-      #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+      #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
         result = _vsnprintf(d,c,f,valist);
-      #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+      #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
         result = vsnprintf(d,c,f,valist);
       #else
         #error Sorry, we do not recognize this system...
@@ -453,9 +455,9 @@
       int result;
       va_list valist;
       va_start(valist,f);
-      #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+      #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
         result = _vsnprintf(d,c,f,valist);
-      #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+      #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
         result = vsnprintf(d,c,f,valist);
       #else
         #error Sorry, we do not recognize this system...
@@ -504,9 +506,9 @@
 * option, and this is the only way to track a problem!!!
 * @see kLOG
 */
-#if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+#if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
   #define kPANIC(msg) ::MessageBox(NULL,msg,"TWAIN Data Source Manager",MB_OK);
-#elif  (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+#elif  (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
   #define kPANIC(msg) fprintf(stderr,"TWAIN Data Source Manager: %s\r\n",msg);
 #else
   #error Sorry, we do not recognize this system...
@@ -894,7 +896,7 @@ class CTwnDsm
                             TW_UINT16    _MSG,
                             TW_MEMREF    _pData);
 
-        #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+        #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
         /**
         * Selection dialog, for apps that don't want to do GetFirst
         * GetNext.  This is only public because of the way that
@@ -909,7 +911,7 @@ class CTwnDsm
                                         UINT _Message,
                                         WPARAM _wParam,
                                         LPARAM _lParam);
-        #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+        #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
             // We don't have one of these...
         #else
             #error Sorry, we do not recognize this system...

--- a/TWAIN_DSM/src/hook.cpp
+++ b/TWAIN_DSM/src/hook.cpp
@@ -80,6 +80,7 @@
 *    WinME, but hopefully nobody is still using that)...
 */
 
+#include <algorithm>
 #include "dsm.h"
 
 
@@ -125,14 +126,14 @@ typedef struct _ANSI_STRING {
 * typedefs of our hooked functions, so we can cast them nice when we make
 * our calls...
 */
-typedef NTSYSAPI DWORD (NTAPI *LdrGetProcedureAddress_t)
+typedef NTAPI DWORD (NTAPI *LdrGetProcedureAddress_t)
 (
   __in     HMODULE       ModuleHandle,
   __in_opt PANSI_STRING  FunctionName,
   __in_opt WORD          Oridinal,
   __out    PVOID        *FunctionAddress
 );
-typedef NTSYSAPI DWORD (NTAPI *LdrGetProcedureAddressForCaller_t)
+typedef NTAPI DWORD (NTAPI *LdrGetProcedureAddressForCaller_t)
 (
   __in     HMODULE       ModuleHandle,
   __in_opt PANSI_STRING  FunctionName,
@@ -580,7 +581,7 @@ bool CTwHook::Hook
 */
 bool CTwHook::DSID_Is_Hooked(TW_UINT32 DSID)
 {
-	int count = min(MAX_NUM_DS,s_iHookCount);
+	int count = std::min(MAX_NUM_DS,s_iHookCount);
 	for (int i=0; i<count; i++)
 	{
 		if (pod.HookedDSs[i] == DSID)
@@ -614,7 +615,7 @@ void CTwHook::Hook_Add_DSID(TW_UINT32 DSID)
 */
 bool CTwHook::Hook_Remove_DSID(TW_UINT32 DSID)
 {
-  int count = min(MAX_NUM_DS, s_iHookCount);
+  int count = std::min(MAX_NUM_DS, s_iHookCount);
 
   for(int i=0; i<count; i++)
   {
@@ -670,7 +671,7 @@ DWORD NTAPI LocalLdrGetProcedureAddress
     // Get and store the original address in case we need it
     (OriginalLdrGetProcedureAddress(ModuleHandle,FunctionName,Ordinal,(PVOID*)&TWAIN32_DSMEntry));
     // Return the address to our own function
-    *FunctionAddress = ::DSM_HookedEntry;
+    *FunctionAddress = (void*) ::DSM_HookedEntry;
     return (ERROR_SUCCESS);
   }
 
@@ -716,7 +717,7 @@ DWORD NTAPI LocalLdrGetProcedureAddressForCaller
     // Get and store the original address in case we need it
     (OriginalLdrGetProcedureAddressForCaller(ModuleHandle,FunctionName,Ordinal,(PVOID*)&TWAIN32_DSMEntry,bValue,CallbackAddress));
     // Return the address to our own function
-    *FunctionAddress = ::DSM_HookedEntry;
+    *FunctionAddress = (void*) ::DSM_HookedEntry;
     return (ERROR_SUCCESS);
   }
 

--- a/TWAIN_DSM/src/log.cpp
+++ b/TWAIN_DSM/src/log.cpp
@@ -189,14 +189,14 @@ void CTwnDsmLog::Log(const int         _doassert,
   const char *file = NULL;
 
   // Grab the system error, this can be really useful...
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     nError = GetLastError();
   if (nError == 0)
   {
     // Yeah, yeah...this is dumb, but I like a clean prefast log...  :)
     nError = 0;
   }
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     nError = errno;
   #else
     #error Sorry, we do not recognize this system...
@@ -216,7 +216,7 @@ void CTwnDsmLog::Log(const int         _doassert,
 
   // Trim the filename down to just the filename, no path...
   file = 0;
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     // Only look for this on Windows...
     file = strrchr(_file,'\\');
   #endif
@@ -237,7 +237,7 @@ void CTwnDsmLog::Log(const int         _doassert,
   }
   
   // Build the message header...
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     SYSTEMTIME st;
     GetLocalTime(&st);
     nChars = SNPRINTF(m_ptwndsmlogimpl->pod.m_message,
@@ -251,7 +251,7 @@ void CTwnDsmLog::Log(const int         _doassert,
                       nError,
                       (void*)(UINT_PTR)GETTHREADID(),
                       m_ptwndsmlogimpl->pod.m_nIndent*2, "            ");
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     timeval tv;
     tm tm;
     gettimeofday(&tv,NULL);
@@ -277,11 +277,11 @@ void CTwnDsmLog::Log(const int         _doassert,
   // Finally, tack on the user portion of the message...
   va_list valist;
   va_start(valist,_format);
-  #if (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP) && (TWNDSM_CMP_VERSION >= 1400)
+  #if (TWNDSM_OS == TWNDSM_OS_WINDOWS) && (TWNDSM_CMP_VERSION >= 1400)
     _vsnprintf_s(message,nChars,nChars,_format,valist);
-  #elif (TWNDSM_CMP == TWNDSM_CMP_VISUALCPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_WINDOWS)
     _vsnprintf(message,nChars,_format,valist);
-  #elif (TWNDSM_CMP == TWNDSM_CMP_GNUGPP)
+  #elif (TWNDSM_OS == TWNDSM_OS_LINUX) || (TWNDSM_OS == TWNDSM_OS_MACOSX)
     vsnprintf(message,nChars,_format,valist);
   #else
     #error Sorry, we do not recognize this system...


### PR DESCRIPTION
This PR contains patches needed to build twaindsm for Windows with MINGW:

 * Do platform detection based on `TWNDSM_OS` instead of `TWNDSM_CMP` throughout the codebase, and ensure `TWNDSM_OS_WINDOWS` is set when compiling with g++ for windows.

 * Tweak CMakeLists.txt to handle mingw build 

 * Some other build error fixes